### PR TITLE
feat: Add database status display to notebooks

### DIFF
--- a/Build Dioceses Database.ipynb
+++ b/Build Dioceses Database.ipynb
@@ -30,6 +30,29 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "import-db-utils-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 1.1: Import display_database_status from db_utils.py\n",
+        "import sys\n",
+        "import os\n",
+        "# Assuming db_utils.py is in the root of the repo, and notebooks might be run from repo root\n",
+        "# If notebooks are in a subdirectory, this might need adjustment, but for now, let's assume repo root.\n",
+        "if '.' not in sys.path: # Add current dir to path if not already there\n",
+        "    sys.path.insert(0, '.')\n",
+        "try:\n",
+        "    from db_utils import display_database_status\n",
+        "    print(\"Successfully imported display_database_status from db_utils.py\")\n",
+        "except ImportError as e:\n",
+        "    print(f\"Error importing display_database_status: {e}\")\n",
+        "    print(\"Make sure db_utils.py is in the same directory or sys.path is configured correctly.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
         "id": "hhF7zOWbH9fN"
       },
       "outputs": [],
@@ -90,6 +113,21 @@
       },
       "execution_count": null,
       "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "initial-db-status-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 2.1: Display initial database status\n",
+        "# This is after cloning the repo and before database operations.\n",
+        "# The CWD should be the repo root due to os.chdir in the previous cell.\n",
+        "print(\"--- Displaying Initial Database Status ---\")\n",
+        "display_database_status('data.db')"
+      ]
     },
     {
       "cell_type": "code",
@@ -176,6 +214,19 @@
       },
       "execution_count": null,
       "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "final-db-status-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 9.1: Display final database status with details\n",
+        "print(\"--- Displaying Final Database Status (with details for Dioceses table) ---\")\n",
+        "display_database_status('data.db', show_details=True, tables_to_show=['Dioceses'])"
+      ]
     },
     {
       "cell_type": "code",

--- a/Build_Parishes_Database_From_Map.ipynb
+++ b/Build_Parishes_Database_From_Map.ipynb
@@ -94,6 +94,21 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "initial-db-status-map-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 2.1: Display initial database status\n",
+        "# This is after cloning the repo and before database operations.\n",
+        "# The CWD should be the repo root due to os.chdir in the previous cell.\n",
+        "print(\"--- Displaying Initial Database Status (Build_Parishes_Database_From_Map.ipynb) ---\")\n",
+        "display_database_status('data.db')"
+      ]
+    },
+    {
+      "cell_type": "code",
       "source": [
         "# Cell 3\n",
         "import time\n",
@@ -115,6 +130,28 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import-db-utils-map-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 3.1: Import display_database_status from db_utils.py\n",
+        "import sys\n",
+        "import os\n",
+        "# Assuming db_utils.py is in the root of the repo\n",
+        "if '.' not in sys.path: # Add current dir to path if not already there\n",
+        "    sys.path.insert(0, '.')\n",
+        "try:\n",
+        "    from db_utils import display_database_status\n",
+        "    print(\"Successfully imported display_database_status from db_utils.py\")\n",
+        "except ImportError as e:\n",
+        "    print(f\"Error importing display_database_status: {e}\")\n",
+        "    print(\"Make sure db_utils.py is in the same directory or sys.path is configured correctly.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
       "source": [
         "# Cell 4: Set up Selenium with Chrome\n",
         "options = webdriver.ChromeOptions()\n",
@@ -130,6 +167,19 @@
       },
       "execution_count": null,
       "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "final-db-status-map-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 9.1: Display final database status with details for parishes table\n",
+        "print(\"--- Displaying Final Database Status (Build_Parishes_Database_From_Map.ipynb) ---\")\n",
+        "display_database_status('data.db', show_details=True, tables_to_show=['parishes'])"
+      ]
     },
     {
       "cell_type": "code",

--- a/Build_Parishes_Database_From_Table.ipynb
+++ b/Build_Parishes_Database_From_Table.ipynb
@@ -30,6 +30,28 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "import-db-utils-table-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 1.1: Import display_database_status from db_utils.py\n",
+        "import sys\n",
+        "import os\n",
+        "# Assuming db_utils.py is in the root of the repo\n",
+        "if '.' not in sys.path: # Add current dir to path if not already there\n",
+        "    sys.path.insert(0, '.')\n",
+        "try:\n",
+        "    from db_utils import display_database_status\n",
+        "    print(\"Successfully imported display_database_status from db_utils.py\")\n",
+        "except ImportError as e:\n",
+        "    print(f\"Error importing display_database_status: {e}\")\n",
+        "    print(\"Make sure db_utils.py is in the same directory or sys.path is configured correctly.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
         "id": "qIm-qDFgrqK3"
       },
       "outputs": [],
@@ -79,6 +101,20 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "initial-db-status-table-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 2.1: Display initial database status\n",
+        "# This is after cloning the repo and before database operations.\n",
+        "print(\"--- Displaying Initial Database Status (Build_Parishes_Database_From_Table.ipynb) ---\")\n",
+        "display_database_status('data.db')"
+      ]
+    },
+    {
+      "cell_type": "code",
       "source": [
         "# Cell 3: Retrieve URLs from the database\n",
         "conn = sqlite3.connect('data.db')\n",
@@ -93,6 +129,19 @@
       },
       "execution_count": null,
       "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "final-db-status-table-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 4.1: Display final database status with details\n",
+        "print(\"--- Displaying Final Database Status (Build_Parishes_Database_From_Table.ipynb) ---\")\n",
+        "display_database_status('data.db', show_details=True)"
+      ]
     },
     {
       "cell_type": "code",

--- a/Build_Parishes_Database_Using_AgenticAI.ipynb
+++ b/Build_Parishes_Database_Using_AgenticAI.ipynb
@@ -27,6 +27,27 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import-db-utils-ai-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 1.1: Import display_database_status from db_utils.py\n",
+        "import sys\n",
+        "import os\n",
+        "if '.' not in sys.path:\n",
+        "    sys.path.insert(0, '.')\n",
+        "try:\n",
+        "    from db_utils import display_database_status\n",
+        "    print(\"Successfully imported display_database_status from db_utils.py\")\n",
+        "except ImportError as e:\n",
+        "    print(f\"Error importing display_database_status: {e}\")\n",
+        "    print(\"Make sure db_utils.py is in the same directory or sys.path is configured correctly.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": 6,
       "metadata": {
         "id": "qIm-qDFgrqK3",
@@ -124,6 +145,20 @@
             "Resolving deltas: 100% (113/113), done.\n"
           ]
         }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "initial-db-status-ai-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 2.1: Display initial database status\n",
+        "# This is after cloning the repo and before database operations.\n",
+        "print(\"--- Displaying Initial Database Status (Build_Parishes_Database_Using_AgenticAI.ipynb) ---\")\n",
+        "display_database_status('data.db')"
       ]
     },
     {
@@ -306,6 +341,19 @@
             "All URLs processed.\n"
           ]
         }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "final-db-status-ai-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# Cell 4.1: Display final database status with details for Parishes table\n",
+        "print(\"--- Displaying Final Database Status (Build_Parishes_Database_Using_AgenticAI.ipynb) ---\")\n",
+        "display_database_status('data.db', show_details=True, tables_to_show=['Parishes'])"
       ]
     },
     {

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,0 +1,188 @@
+import sqlite3
+import pandas as pd
+
+def connect_db(db_path):
+    """
+    Connects to the SQLite database at db_path.
+
+    Args:
+        db_path (str): The path to the SQLite database file.
+
+    Returns:
+        sqlite3.Connection: The connection object or None if connection fails.
+    """
+    try:
+        conn = sqlite3.connect(db_path)
+        return conn
+    except sqlite3.Error as e:
+        print(f"Error connecting to database {db_path}: {e}")
+        return None
+
+def get_db_summary(conn):
+    """
+    Gets a summary of the database, including table names and row counts.
+
+    Args:
+        conn (sqlite3.Connection): The database connection object.
+
+    Returns:
+        str: A human-readable string summarizing the database contents.
+    """
+    if not conn:
+        return "No database connection."
+
+    summary_lines = []
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables = cursor.fetchall()
+
+        if not tables:
+            return "No tables found in the database."
+
+        summary_lines.append("Database Summary:")
+        for table_name_tuple in tables:
+            table_name = table_name_tuple[0]
+            try:
+                cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+                count = cursor.fetchone()[0]
+                summary_lines.append(f"  Table: {table_name} - Rows: {count}")
+            except sqlite3.Error as e:
+                summary_lines.append(f"  Table: {table_name} - Error counting rows: {e}")
+        return "\n".join(summary_lines)
+    except sqlite3.Error as e:
+        return f"Error querying sqlite_master: {e}"
+
+def get_table_details(conn, table_name, limit=5):
+    """
+    Fetches details (a few rows) from a specific table.
+
+    Args:
+        conn (sqlite3.Connection): The database connection object.
+        table_name (str): The name of the table to query.
+        limit (int, optional): The maximum number of rows to fetch. Defaults to 5.
+
+    Returns:
+        pandas.DataFrame or tuple: A pandas DataFrame with the table data if pandas is available,
+                                   otherwise a tuple containing a list of tuples (rows)
+                                   and a list of column names. Returns None on error.
+    """
+    if not conn:
+        return None
+
+    try:
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT * FROM {table_name} LIMIT ?", (limit,))
+        rows = cursor.fetchall()
+        column_names = [description[0] for description in cursor.description]
+
+        try:
+            # Try to use pandas for nice formatting
+            return pd.DataFrame(rows, columns=column_names)
+        except ImportError:
+            # Fallback if pandas is not available
+            return rows, column_names
+    except sqlite3.Error as e:
+        print(f"Error fetching details for table {table_name}: {e}")
+        return None
+
+def display_database_status(db_path="data.db", show_details=False, tables_to_show=None, limit_details=5):
+    """
+    Main function to display database status, summary, and optionally table details.
+
+    Args:
+        db_path (str, optional): Path to the database file. Defaults to "data.db".
+        show_details (bool, optional): Whether to show details for tables. Defaults to False.
+        tables_to_show (list, optional): A list of specific table names to show details for.
+                                         If None, and show_details is True, details for all tables are shown.
+                                         Defaults to None.
+        limit_details (int, optional): The number of rows to display for each table's details.
+                                       Defaults to 5.
+    """
+    conn = connect_db(db_path)
+    if not conn:
+        # connect_db already prints an error
+        return
+
+    try:
+        print(f"Connecting to database: {db_path}")
+        summary = get_db_summary(conn)
+        print(summary)
+
+        if show_details:
+            print("\nTable Details:")
+            tables_to_query = tables_to_show
+            if tables_to_query is None:
+                # Get all table names if specific ones aren't provided
+                try:
+                    cursor = conn.cursor()
+                    cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+                    tables_to_query = [row[0] for row in cursor.fetchall()]
+                except sqlite3.Error as e:
+                    print(f"Error fetching list of all tables: {e}")
+                    tables_to_query = [] # Avoid further errors
+
+            if not tables_to_query:
+                print("  No tables specified or found to show details for.")
+            else:
+                for table_name in tables_to_query:
+                    print(f"\n  Details for table {table_name} (limit {limit_details}):")
+                    details = get_table_details(conn, table_name, limit=limit_details)
+                    if details is not None:
+                        if isinstance(details, tuple): # Fallback mode (list of tuples, column_names)
+                            rows, colnames = details
+                            if rows:
+                                print(f"    Columns: {', '.join(colnames)}")
+                                for row_idx, row in enumerate(rows):
+                                    print(f"      Row {row_idx + 1}: {row}")
+                            else:
+                                print("    No data found in this table.")
+                        else: # pandas DataFrame
+                            if not details.empty:
+                                print(details.to_string(index=False))
+                            else:
+                                print("    No data found in this table.")
+                    # Error message already printed by get_table_details if details is None
+    finally:
+        if conn:
+            print(f"\nClosing database connection: {db_path}")
+            conn.close()
+
+if __name__ == '__main__':
+    # Example Usage (for testing purposes)
+    # This part will only run when the script is executed directly.
+    # Create a dummy database for testing
+    DB_FILE = "test_db.sqlite"
+    conn_test = sqlite3.connect(DB_FILE)
+    cursor_test = conn_test.cursor()
+    cursor_test.execute("DROP TABLE IF EXISTS users")
+    cursor_test.execute("DROP TABLE IF EXISTS products")
+    cursor_test.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)")
+    cursor_test.execute("CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, price REAL)")
+    cursor_test.execute("INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')")
+    cursor_test.execute("INSERT INTO users (name, email) VALUES ('Bob', 'bob@example.com')")
+    cursor_test.execute("INSERT INTO products (name, price) VALUES ('Laptop', 1200.50)")
+    cursor_test.execute("INSERT INTO products (name, price) VALUES ('Mouse', 25.99)")
+    cursor_test.execute("INSERT INTO products (name, price) VALUES ('Keyboard', 75.00)")
+    conn_test.commit()
+    conn_test.close()
+
+    print("--- Running display_database_status (summary only) ---")
+    display_database_status(db_path=DB_FILE)
+
+    print("\n--- Running display_database_status (with details for all tables) ---")
+    display_database_status(db_path=DB_FILE, show_details=True, limit_details=2)
+
+    print("\n--- Running display_database_status (with details for 'users' table) ---")
+    display_database_status(db_path=DB_FILE, show_details=True, tables_to_show=['users'], limit_details=3)
+
+    print("\n--- Running display_database_status (with details for non-existent table) ---")
+    display_database_status(db_path=DB_FILE, show_details=True, tables_to_show=['non_existent_table'])
+
+    print("\n--- Running display_database_status (for non-existent database) ---")
+    display_database_status(db_path="non_existent.db")
+
+    # Clean up the dummy database
+    import os
+    os.remove(DB_FILE)
+    print(f"\nCleaned up {DB_FILE}")


### PR DESCRIPTION
I've created a new module `db_utils.py` with functions to display SQLite database summary (table names and row counts) and detailed table contents (first N rows). This module uses pandas for formatting details when available.

I've integrated `db_utils.py` into the following notebooks:
- `Build Dioceses Database.ipynb`
- `Build_Parishes_Database_From_Map.ipynb`
- `Build_Parishes_Database_From_Table.ipynb`
- `Build_Parishes_Database_Using_AgenticAI.ipynb`

In each notebook:
1. I added a cell to import `display_database_status` from `db_utils.py`.
2. I added a cell to call `display_database_status('data.db')` near the beginning of the notebook run (after setup, before DB modifications) to show you the initial state of the database.
3. I added a cell to call `display_database_status('data.db', show_details=True, ...)` near the end of the notebook run (after DB modifications) to show you the final state and the number of records added/changed. The `tables_to_show` parameter is tailored for each notebook based on the tables it modifies.

This will allow you to see a summary of database changes resulting from each notebook run. Testing of full notebook execution was limited by environment timeouts, but the utility module `db_utils.py` includes its own tests, and integrations were performed systematically.